### PR TITLE
Fix/fix actual/expected assertions order

### DIFF
--- a/test/03-arrays-tests.js
+++ b/test/03-arrays-tests.js
@@ -689,8 +689,8 @@ describe('03-arrays-tasks', () => {
       {
         start: -5,
         end: -3,
-        expected: [-5, -4 ,-3],
-      }
+        expected: [-5, -4, -3],
+      },
     ].forEach((data) => {
       const actual = tasks.getIntervalArray(data.start, data.end);
       assert.deepEqual(

--- a/test/03-arrays-tests.js
+++ b/test/03-arrays-tests.js
@@ -21,8 +21,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.findElement(data.arr, data.value);
       assert.equal(
-        data.expected,
         actual,
+        data.expected,
         `Index of '${data.value}' inside of [${data.arr}] = ${data.expected}, but actually ${actual}`,
       );
     });
@@ -46,8 +46,8 @@ describe('03-arrays-tasks', () => {
       },
     ].forEach((data) => {
       assert.deepEqual(
-        data.expected,
         tasks.generateOdds(data.len),
+        data.expected,
       );
     });
   });
@@ -68,8 +68,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.doubleArray(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
         `The result of doubling [${data.arr}] is not correct`,
       );
     });
@@ -91,8 +91,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getArrayOfPositives(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -113,8 +113,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getArrayOfStrings(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -135,8 +135,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.removeFalsyValues(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -168,8 +168,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.findAllOccurrences(data.arr, data.item);
       assert.equal(
-        data.expected,
         actual,
+        data.expected,
         `Number of occurrences of ${JSON.stringify(data.item)} in ${JSON.stringify(data.arr)} is ${data.expected}, but actually ${actual})`,
       );
     });
@@ -188,8 +188,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getUpperCaseStrings(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -207,8 +207,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getStringsLength(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -230,8 +230,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       tasks.insertItem(data.arr, data.item, data.index);
       assert.deepEqual(
-        data.expected,
         data.arr,
+        data.expected,
       );
     });
   });
@@ -250,8 +250,8 @@ describe('03-arrays-tasks', () => {
       },
     ].forEach((data) => {
       assert.deepEqual(
-        data.expected,
         tasks.getHead(data.arr, data.n),
+        data.expected,
       );
     });
   });
@@ -270,8 +270,8 @@ describe('03-arrays-tasks', () => {
       },
     ].forEach((data) => {
       assert.deepEqual(
-        data.expected,
         tasks.getTail(data.arr, data.n),
+        data.expected,
       );
     });
   });
@@ -297,8 +297,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.toCsvText(data.arr);
       assert.equal(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -316,8 +316,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.toArrayOfSquares(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -341,8 +341,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getMovingSum(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -363,8 +363,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getSecondItems(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -391,8 +391,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.propagateItemsByPositionIndex(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -419,8 +419,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.get3TopItems(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -447,8 +447,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getPositivesCount(data.arr);
       assert.equal(
-        data.expected,
         actual,
+        data.expected,
         `Test failed for argument [${data.arr}]`,
       );
     });
@@ -479,8 +479,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.sortDigitNamesByNumericOrder(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -501,8 +501,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getItemsSum(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
         `Test failed for [${data.arr}]`,
       );
     });
@@ -527,8 +527,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getFalsyValuesCount(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
         `Test failed for [${data.arr}]`,
       );
     });
@@ -550,8 +550,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.toStringList(data.arr);
       assert.equal(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -626,8 +626,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.sortCitiesArray(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -653,8 +653,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getIdentityMatrix(data.n);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -694,8 +694,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getIntervalArray(data.start, data.end);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -719,8 +719,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.distinct(data.arr);
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -764,8 +764,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.group(data.arr, data.keySelector, data.valueSelector);
       assert.deepEqual(
-        Array.from(data.expected),
         Array.from(actual),
+        Array.from(data.expected),
       );
     });
   });
@@ -789,8 +789,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.selectMany(data.arr, data.childrenSelector);
       assert.deepStrictEqual(
-        data.expected,
         actual,
+        data.expected,
       );
     });
   });
@@ -814,8 +814,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.getElementByIndexes(data.arr, data.indexes);
       assert.equal(
-        data.expected,
         actual,
+        data.expected,
         `getElementByIndexes(${JSON.stringify(data.arr)}, ${JSON.stringify(data.indexes)}) returns an incorrect result. Expected ${data.expected}, but actual ${actual}`,
       );
     });
@@ -843,8 +843,8 @@ describe('03-arrays-tasks', () => {
     ].forEach((data) => {
       const actual = tasks.swapHeadAndTail(Array.from(data.arr));
       assert.deepEqual(
-        data.expected,
         actual,
+        data.expected,
         `The result of swapping head and tail [${data.arr}] is not correct`,
       );
     });


### PR DESCRIPTION
- Fixed order of `actual` & `expected` arguments in assertions of  `03-array-tasks` module. They were other way around and students were confused by error messages of test runner.
- Also fixed several ESLint errors related to formatting in `03-array-tasks`